### PR TITLE
Adding missing function and unit tests

### DIFF
--- a/src/approach/gdumb.py
+++ b/src/approach/gdumb.py
@@ -4,9 +4,47 @@ from copy import deepcopy
 from argparse import ArgumentParser
 from torch.utils.data.dataloader import default_collate
 
-from utils import cutmix_data
 from .incremental_learning import Inc_Learning_Appr
 from datasets.exemplars_dataset import ExemplarsDataset
+
+
+def rand_bbox(size, lam):
+    W = size[2]
+    H = size[3]
+    cut_rat = np.sqrt(1. - lam)
+    cut_w = np.int(W * cut_rat)
+    cut_h = np.int(H * cut_rat)
+
+    # uniform
+    cx = np.random.randint(W)
+    cy = np.random.randint(H)
+
+    bbx1 = np.clip(cx - cut_w // 2, 0, W)
+    bby1 = np.clip(cy - cut_h // 2, 0, H)
+    bbx2 = np.clip(cx + cut_w // 2, 0, W)
+    bby2 = np.clip(cy + cut_h // 2, 0, H)
+
+    return bbx1, bby1, bbx2, bby2
+
+
+def cutmix_data(x, y, alpha=1.0, cutmix_prob=0.5):
+    assert(alpha > 0)
+    # generate mixed sample
+    lam = np.random.beta(alpha, alpha)
+
+    batch_size = x.size()[0]
+    index = torch.randperm(batch_size)
+
+    if torch.cuda.is_available():
+        index = index.cuda()
+
+    y_a, y_b = y, y[index]
+    bbx1, bby1, bbx2, bby2 = rand_bbox(x.size(), lam)
+    x[:, :, bbx1:bbx2, bby1:bby2] = x[index, :, bbx1:bbx2, bby1:bby2]
+
+    # adjust lambda to exactly match pixel ratio
+    lam = 1 - ((bbx2 - bbx1) * (bby2 - bby1) / (x.size()[-1] * x.size()[-2]))
+    return x, y_a, y_b, lam
 
 
 class Appr(Inc_Learning_Appr):

--- a/src/tests/test_gdumb.py
+++ b/src/tests/test_gdumb.py
@@ -1,0 +1,32 @@
+import pytest
+
+from tests import run_main_and_assert
+
+FAST_LOCAL_TEST_ARGS = "--exp-name local_test --datasets mnist" \
+                       " --network LeNet --num-tasks 3 --seed 1 --batch-size 32" \
+                       " --nepochs 2 --lr-factor 10 --momentum 0.9 --lr-min 1e-7" \
+                       " --num-workers 0"
+
+
+
+def test_gdumb():
+    args_line = FAST_LOCAL_TEST_ARGS
+    args_line += " --approach gdumb"
+    args_line += " --num-exemplars 200"
+    run_main_and_assert(args_line)
+
+
+@pytest.mark.xfail
+def test_gdumb_with_exemplars_per_class_and_herding():
+    args_line = FAST_LOCAL_TEST_ARGS
+    args_line += " --approach gdumb"
+    args_line += " --num-exemplars-per-class 0"
+    run_main_and_assert(args_line)
+
+
+def test_gdumb_without_catmix():
+    args_line = FAST_LOCAL_TEST_ARGS
+    args_line += " --approach gdumb"
+    args_line += " --regularization none"
+    args_line += " --num-exemplars 200"
+    run_main_and_assert(args_line)


### PR DESCRIPTION
This change will add unit test and missing `cutmix_data()` function imported from `utils.py`.
I added it directly to `gdumb.py` because it's not use anywhere else. For me that's the indicator to not place something to very generic places like `utils`. Whenever more approaches use it, we can move it `utils` or separate module.